### PR TITLE
HDFS greedy EC read support

### DIFF
--- a/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/fs/CommonConfigurationKeysPublic.java
+++ b/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/fs/CommonConfigurationKeysPublic.java
@@ -122,15 +122,30 @@ public class CommonConfigurationKeysPublic {
   public static final String  NET_LINK_SCRIPT_FILE_NAME_KEY =
     "net.link.script.file.name";
 
+  /** Default link cost to be considered if link script has not been provided or
+   * if the script fails.
+   */
   public static final String  NET_LINK_DEFAULT_COST_KEY =
     "net.link.default.cost";
   /** Default value for NET_LINK_DEFAULT_COST_KEY */
   public static final int  NET_LINK_DEFAULT_COST_DEFAULT = 1;
 
+  /** The same rack penalty to be considered during our greedy link cost based
+   * heuristics.
+   */
   public static final String  NET_LINK_SAME_RACK_PENALTY_KEY =
     "net.link.samerack.penalty";
   /** Default value for NET_LINK_SAME_RACK_PENALTY_KEY */
   public static final int  NET_LINK_SAME_RACK_PENALTY_DEFAULT = 5;
+
+  /** Can be used to disable pipeline sorting. This may be needed if you want
+   * the greedy heuristics to be followed in the exact precise order in which
+   * results were picked.
+   */
+  public static final String  NET_LINK_DISABLE_PIPELINE_SORT_KEY =
+    "net.link.disable.pipeline.sort";
+  /** Default value for NET_LINK_DISABLE_PIPELINE_SORT_KEY */
+  public static final boolean  NET_LINK_DISABLE_PIPELINE_SORT_DEFAULT = false;
 
   /**
    * @see

--- a/hadoop-hdfs-project/hadoop-hdfs-client/src/main/java/org/apache/hadoop/hdfs/client/HdfsClientConfigKeys.java
+++ b/hadoop-hdfs-project/hadoop-hdfs-client/src/main/java/org/apache/hadoop/hdfs/client/HdfsClientConfigKeys.java
@@ -103,6 +103,8 @@ public interface HdfsClientConfigKeys {
   String  DFS_CLIENT_DATANODE_RESTART_TIMEOUT_KEY =
       "dfs.client.datanode-restart.timeout";
   long    DFS_CLIENT_DATANODE_RESTART_TIMEOUT_DEFAULT = 30;
+  String  DFS_CLIENT_PARITY_COMPUTATION_COST_KEY = "dfs.client.parity.comp.cost";
+  int     DFS_CLIENT_PARITY_COMPUTATION_COST_DEFAULT = 1000;
   // Much code in hdfs is not yet updated to use these keys.
   // the initial delay (unit is ms) for locateFollowingBlock, the delay time
   // will increase exponentially(double) for each retry.

--- a/hadoop-hdfs-project/hadoop-hdfs-client/src/main/java/org/apache/hadoop/hdfs/client/impl/DfsClientConf.java
+++ b/hadoop-hdfs-project/hadoop-hdfs-client/src/main/java/org/apache/hadoop/hdfs/client/impl/DfsClientConf.java
@@ -44,6 +44,8 @@ import static org.apache.hadoop.hdfs.client.HdfsClientConfigKeys.DFS_CLIENT_CACH
 import static org.apache.hadoop.hdfs.client.HdfsClientConfigKeys.DFS_CLIENT_CACHED_CONN_RETRY_KEY;
 import static org.apache.hadoop.hdfs.client.HdfsClientConfigKeys.DFS_CLIENT_DATANODE_RESTART_TIMEOUT_DEFAULT;
 import static org.apache.hadoop.hdfs.client.HdfsClientConfigKeys.DFS_CLIENT_DATANODE_RESTART_TIMEOUT_KEY;
+import static org.apache.hadoop.hdfs.client.HdfsClientConfigKeys.DFS_CLIENT_PARITY_COMPUTATION_COST_KEY;
+import static org.apache.hadoop.hdfs.client.HdfsClientConfigKeys.DFS_CLIENT_PARITY_COMPUTATION_COST_DEFAULT;
 import static org.apache.hadoop.hdfs.client.HdfsClientConfigKeys.DFS_CLIENT_DOMAIN_SOCKET_DATA_TRAFFIC;
 import static org.apache.hadoop.hdfs.client.HdfsClientConfigKeys.DFS_CLIENT_DOMAIN_SOCKET_DATA_TRAFFIC_DEFAULT;
 import static org.apache.hadoop.hdfs.client.HdfsClientConfigKeys.DFS_CLIENT_KEY_PROVIDER_CACHE_EXPIRY_DEFAULT;
@@ -125,6 +127,7 @@ public class DfsClientConf {
   private final int retryIntervalForGetLastBlockLength;
   private final long datanodeRestartTimeout;
   private final long slowIoWarningThresholdMs;
+  private final int parityComputationCost;
 
   private final ShortCircuitConf shortCircuitConf;
 
@@ -239,6 +242,9 @@ public class DfsClientConf {
     slowIoWarningThresholdMs = conf.getLong(
         DFS_CLIENT_SLOW_IO_WARNING_THRESHOLD_KEY,
         DFS_CLIENT_SLOW_IO_WARNING_THRESHOLD_DEFAULT);
+    parityComputationCost = conf.getInt(
+        DFS_CLIENT_PARITY_COMPUTATION_COST_KEY,
+        DFS_CLIENT_PARITY_COMPUTATION_COST_DEFAULT);
 
     shortCircuitConf = new ShortCircuitConf(conf);
 
@@ -526,6 +532,13 @@ public class DfsClientConf {
    */
   public long getDatanodeRestartTimeout() {
     return datanodeRestartTimeout;
+  }
+
+  /**
+   * @return the parityComputationCost
+   */
+  public int getParityComputationCost() {
+    return parityComputationCost;
   }
 
   /**

--- a/hadoop-hdfs-project/hadoop-hdfs-client/src/main/java/org/apache/hadoop/hdfs/protocol/LocatedStripedBlock.java
+++ b/hadoop-hdfs-project/hadoop-hdfs-client/src/main/java/org/apache/hadoop/hdfs/protocol/LocatedStripedBlock.java
@@ -17,11 +17,14 @@
  */
 package org.apache.hadoop.hdfs.protocol;
 
+import java.util.List;
+import java.util.HashMap;
 import org.apache.hadoop.classification.InterfaceAudience;
 import org.apache.hadoop.classification.InterfaceStability;
 import org.apache.hadoop.fs.StorageType;
 import org.apache.hadoop.hdfs.security.token.block.BlockTokenIdentifier;
 import org.apache.hadoop.security.token.Token;
+import org.apache.hadoop.net.*;
 
 import java.util.Arrays;
 
@@ -39,6 +42,8 @@ public class LocatedStripedBlock extends LocatedBlock {
   private final byte[] blockIndices;
   private Token<BlockTokenIdentifier>[] blockTokens;
 
+  private int[] linkCosts;
+
   @SuppressWarnings({"unchecked"})
   public LocatedStripedBlock(ExtendedBlock b, DatanodeInfo[] locs,
       String[] storageIDs, StorageType[] storageTypes, byte[] indices,
@@ -55,6 +60,7 @@ public class LocatedStripedBlock extends LocatedBlock {
     for (int i = 0; i < blockIndices.length; i++) {
       blockTokens[i] = EMPTY_TOKEN;
     }
+    linkCosts = new int[this.getLocations().length];
   }
 
   @Override
@@ -83,5 +89,12 @@ public class LocatedStripedBlock extends LocatedBlock {
 
   public void setBlockTokens(Token<BlockTokenIdentifier>[] tokens) {
     this.blockTokens = tokens;
+  }
+
+  public void setLinkCosts(int[] costs) {
+    this.linkCosts = costs;
+  }
+  public int[] getLinkCosts() {
+    return this.linkCosts;
   }
 }

--- a/hadoop-hdfs-project/hadoop-hdfs-client/src/main/java/org/apache/hadoop/hdfs/protocolPB/PBHelperClient.java
+++ b/hadoop-hdfs-project/hadoop-hdfs-client/src/main/java/org/apache/hadoop/hdfs/protocolPB/PBHelperClient.java
@@ -562,10 +562,23 @@ public class PBHelperClient {
       Token<BlockTokenIdentifier>[] blockTokens =
           convertTokens(tokenProtos);
       ((LocatedStripedBlock) lb).setBlockTokens(blockTokens);
+      int[] linkCosts = convertLinkCosts(proto.getLinkCostsList());
+      ((LocatedStripedBlock) lb).setLinkCosts(linkCosts);
     }
     lb.setBlockToken(convert(proto.getBlockToken()));
 
     return lb;
+  }
+
+  static public int[] convertLinkCosts(List<Integer> protoCosts) {
+
+    @SuppressWarnings("unchecked")
+    int[] costs = new int[protoCosts.size()];
+    for (int i = 0; i < costs.length; i++) {
+      costs[i] = protoCosts.get(i);
+    }
+
+    return costs;
   }
 
   static public Token<BlockTokenIdentifier>[] convertTokens(
@@ -836,11 +849,21 @@ public class PBHelperClient {
       builder.setBlockIndices(PBHelperClient.getByteString(indices));
       Token<BlockTokenIdentifier>[] blockTokens = sb.getBlockTokens();
       builder.addAllBlockTokens(convert(blockTokens));
+      int[] linkCosts = sb.getLinkCosts();
+      builder.addAllLinkCosts(convertLinkCosts(linkCosts));
     }
 
     return builder.setB(PBHelperClient.convert(b.getBlock()))
         .setBlockToken(PBHelperClient.convert(b.getBlockToken()))
         .setCorrupt(b.isCorrupt()).setOffset(b.getStartOffset()).build();
+  }
+
+  public static List<Integer> convertLinkCosts(int[] linkCosts) {
+    List<Integer> results = new ArrayList<>(linkCosts.length);
+    for (int i = 0; i < linkCosts.length; i++) {
+      results.add(linkCosts[i]);
+    }
+    return results;
   }
 
   public static List<TokenProto> convert(

--- a/hadoop-hdfs-project/hadoop-hdfs-client/src/main/proto/hdfs.proto
+++ b/hadoop-hdfs-project/hadoop-hdfs-client/src/main/proto/hdfs.proto
@@ -236,6 +236,7 @@ message LocatedBlockProto {
   // striped block related fields
   optional bytes blockIndices = 9; // used for striped block to indicate block index for each storage
   repeated hadoop.common.TokenProto blockTokens = 10; // each internal block has a block token
+  repeated uint32 linkCosts = 11; // used for storing link cost to each DatanodeInfo
 }
 
 message DataEncryptionKeyProto {

--- a/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/DFSConfigKeys.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/DFSConfigKeys.java
@@ -1278,6 +1278,11 @@ public class DFSConfigKeys extends CommonConfigurationKeys {
   public static final long    DFS_CLIENT_DATANODE_RESTART_TIMEOUT_DEFAULT =
       HdfsClientConfigKeys.DFS_CLIENT_DATANODE_RESTART_TIMEOUT_DEFAULT;
 
+  public static final String  DFS_CLIENT_PARITY_COMPUTATION_COST_KEY =
+      HdfsClientConfigKeys.DFS_CLIENT_PARITY_COMPUTATION_COST_KEY;
+  public static final long    DFS_CLIENT_PARITY_COMPUTATION_COST_DEFAULT =
+      HdfsClientConfigKeys.DFS_CLIENT_PARITY_COMPUTATION_COST_DEFAULT;
+
   public static final String  DFS_CLIENT_HTTPS_KEYSTORE_RESOURCE_KEY =
       HdfsClientConfigKeys.DeprecatedKeys.DFS_CLIENT_HTTPS_KEYSTORE_RESOURCE_KEY;
   public static final String  DFS_CLIENT_HTTPS_KEYSTORE_RESOURCE_DEFAULT = "ssl-client.xml";

--- a/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/blockmanagement/BlockPlacementPolicyDefault.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/blockmanagement/BlockPlacementPolicyDefault.java
@@ -878,7 +878,7 @@ public class BlockPlacementPolicyDefault extends BlockPlacementPolicy {
    * starts from the writer and traverses all <i>nodes</i>
    * This is basically a traveling salesman problem.
    */
-  private DatanodeStorageInfo[] getPipeline(Node writer,
+  protected DatanodeStorageInfo[] getPipeline(Node writer,
       DatanodeStorageInfo[] storages) {
     if (storages.length == 0) {
       return storages;

--- a/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/TestDFSStripedInputStreamGDA.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/TestDFSStripedInputStreamGDA.java
@@ -1,0 +1,280 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.hadoop.hdfs;
+
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
+import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.fs.CommonConfigurationKeys;
+import org.apache.hadoop.fs.FileUtil;
+import org.apache.hadoop.fs.Path;
+import org.apache.hadoop.hdfs.protocol.Block;
+import org.apache.hadoop.hdfs.protocol.ErasureCodingPolicy;
+import org.apache.hadoop.hdfs.protocol.LocatedBlock;
+import org.apache.hadoop.hdfs.protocol.LocatedBlocks;
+import org.apache.hadoop.hdfs.protocol.LocatedStripedBlock;
+import org.apache.hadoop.hdfs.server.datanode.DataNode;
+import org.apache.hadoop.hdfs.server.datanode.DataNodeTestUtils;
+import org.apache.hadoop.hdfs.server.datanode.SimulatedFSDataset;
+import org.apache.hadoop.hdfs.server.namenode.ErasureCodingPolicyManager;
+import org.apache.hadoop.hdfs.util.StripedBlockUtil;
+import org.apache.hadoop.io.erasurecode.CodecUtil;
+import org.apache.hadoop.io.erasurecode.ErasureCodeNative;
+import org.apache.hadoop.io.erasurecode.ErasureCoderOptions;
+import org.apache.hadoop.io.erasurecode.rawcoder.NativeRSRawErasureCoderFactory;
+import org.apache.hadoop.io.erasurecode.rawcoder.RawErasureDecoder;
+import org.apache.hadoop.util.Shell;
+import org.junit.After;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.Timeout;
+
+import java.io.IOException;
+import java.nio.ByteBuffer;
+import java.util.*;
+import java.io.File;
+import java.io.PrintWriter;
+import java.net.URISyntaxException;
+import java.net.URL;
+import java.nio.file.Paths;
+
+import static org.apache.hadoop.fs.CommonConfigurationKeysPublic.IO_FILE_BUFFER_SIZE_DEFAULT;
+import static org.apache.hadoop.fs.CommonConfigurationKeysPublic.IO_FILE_BUFFER_SIZE_KEY;
+import static org.junit.Assert.assertArrayEquals;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+public class TestDFSStripedInputStreamGDA {
+
+  public static final Log LOG = LogFactory.getLog(TestDFSStripedInputStream.class);
+
+  private MiniDFSCluster cluster;
+  private Configuration conf = new Configuration();
+  private DistributedFileSystem fs;
+  private final Path dirPath = new Path("/striped");
+  private Path filePath = new Path(dirPath, "file");
+  private final ErasureCodingPolicy ecPolicy =
+      ErasureCodingPolicyManager.getSystemDefaultPolicy();
+  private final short DATA_BLK_NUM = StripedFileTestUtil.NUM_DATA_BLOCKS;
+  private final short PARITY_BLK_NUM = StripedFileTestUtil.NUM_PARITY_BLOCKS;
+  private final int CELLSIZE = StripedFileTestUtil.BLOCK_STRIPED_CELL_SIZE;
+  private final int NUM_STRIPE_PER_BLOCK = 2;
+  private final int INTERNAL_BLOCK_SIZE = NUM_STRIPE_PER_BLOCK * CELLSIZE;
+  private final int BLOCK_GROUP_SIZE =  DATA_BLK_NUM * INTERNAL_BLOCK_SIZE;
+
+  private final int remoteDNIdx = DATA_BLK_NUM - 1;
+
+  @Rule
+  public Timeout globalTimeout = new Timeout(300000);
+
+  public void createLinkCostScript(File src) throws IOException {
+    // Populate link costs dictionary. This will be used to generate our script
+    Map<String, Map<String, Integer>> linkCosts =
+        new HashMap<String, Map<String, Integer>>();
+    linkCosts.put("/localRack", new HashMap<String, Integer>());
+    Map<String, Integer> costsLocal = linkCosts.get("/localRack");
+    linkCosts.put("/remoteRack", new HashMap<String, Integer>());
+    Map<String, Integer> costsRemote = linkCosts.get("/remoteRack");
+
+    // Set remote costs such that they are much higher than parity computation
+    // costs.
+    costsLocal.put("/localRack", 0);
+    costsLocal.put("/remoteRack", 1000);
+    costsRemote.put("/localRack", 1000);
+    costsRemote.put("/remoteRack", 0);
+
+    PrintWriter writer = new PrintWriter(src);
+    writer.println("#!/bin/bash");
+    try {
+      for (String rack1 : linkCosts.keySet()) {
+        Map<String, Integer> otherRacks = linkCosts.get(rack1);
+        for (String rack2 : otherRacks.keySet()) {
+          int cost = otherRacks.get(rack2);
+          writer.format(
+              "if [[ \"$1\" == \"%s\" && \"$2\" == \"%s\" ]]; then echo \"%d\"; fi\n",
+              rack1, rack2, cost);
+        }
+      }
+    } finally {
+      writer.close();
+    }
+  }
+
+  @Before
+  public void setup() throws IOException, URISyntaxException {
+    conf.setLong(DFSConfigKeys.DFS_BLOCK_SIZE_KEY, INTERNAL_BLOCK_SIZE);
+    conf.setInt(DFSConfigKeys.DFS_NAMENODE_REPLICATION_MAX_STREAMS_KEY, 0);
+    conf.setInt(DFSConfigKeys.DFS_CLIENT_PARITY_COMPUTATION_COST_KEY, 100);
+    if (ErasureCodeNative.isNativeCodeLoaded()) {
+      conf.set(
+          CommonConfigurationKeys.IO_ERASURECODE_CODEC_RS_DEFAULT_RAWCODER_KEY,
+          NativeRSRawErasureCoderFactory.class.getCanonicalName());
+    }
+    final ArrayList<String> rackList = new ArrayList<String>();
+    final ArrayList<String> hostList = new ArrayList<String>();
+    // Add 2 racks. One rack will have one node, and the other will have
+    // DATA_BLK_NUM + PARITY_BLK_NUM - 1 nodes.
+    for (int i = 0; i < DATA_BLK_NUM + PARITY_BLK_NUM; i++) {
+      if (i == remoteDNIdx) {
+        // Node will be in remote rack
+        rackList.add("/remoteRack");
+      } else {
+        rackList.add("/localRack");
+      }
+      hostList.add("/host" + i);
+    }
+
+    // Setup link cost script.
+    String scriptFileName = "/" +
+        Shell.appendScriptExtension("custom-link-script");
+    assertEquals(true, scriptFileName != null && !scriptFileName.isEmpty());
+    URL shellScript = getClass().getResource(scriptFileName);
+    java.nio.file.Path resourcePath = Paths.get(shellScript.toURI());
+    FileUtil.setExecutable(resourcePath.toFile(), true);
+    FileUtil.setWritable(resourcePath.toFile(), true);
+
+    // Manually create the script with link cost logic
+    createLinkCostScript(resourcePath.toFile());
+    conf.set(DFSConfigKeys.NET_LINK_SCRIPT_FILE_NAME_KEY,
+      resourcePath.toString());
+
+    SimulatedFSDataset.setFactory(conf);
+    cluster = new MiniDFSCluster.Builder(conf)
+        .numDataNodes(DATA_BLK_NUM + PARITY_BLK_NUM)
+        .racks(rackList.toArray(new String[rackList.size()]))
+        .hosts(hostList.toArray(new String[hostList.size()]))
+        .build();
+    cluster.waitActive();
+    for (DataNode dn : cluster.getDataNodes()) {
+      DataNodeTestUtils.setHeartbeatsDisabledForTests(dn, true);
+    }
+    fs = cluster.getFileSystem();
+    fs.mkdirs(dirPath);
+    fs.getClient().setErasureCodingPolicy(dirPath.toString(), null);
+  }
+
+  @After
+  public void tearDown() {
+    if (cluster != null) {
+      cluster.shutdown();
+      cluster = null;
+    }
+  }
+
+  /** Test is copied from TestDFSStripedInputStream.testPreadWithDNFailure.
+   * Instead of a failed datanode, we have a remote datanode. The rest of the
+   * logic remains the same. Our code should work the exact same way.
+   */
+  @Test
+  public void testPreadWithDNRemote() throws Exception {
+    final int numBlocks = 4;
+    DFSTestUtil.createStripedFile(cluster, filePath, null, numBlocks,
+        NUM_STRIPE_PER_BLOCK, false);
+    LocatedBlocks lbs = fs.getClient().namenode.getBlockLocations(
+        filePath.toString(), 0, BLOCK_GROUP_SIZE);
+
+    assert lbs.get(0) instanceof LocatedStripedBlock;
+    LocatedStripedBlock bg = (LocatedStripedBlock)(lbs.get(0));
+    for (int i = 0; i < DATA_BLK_NUM + PARITY_BLK_NUM; i++) {
+      Block blk = new Block(bg.getBlock().getBlockId() + i,
+          NUM_STRIPE_PER_BLOCK * CELLSIZE,
+          bg.getBlock().getGenerationStamp());
+      blk.setGenerationStamp(bg.getBlock().getGenerationStamp());
+      cluster.injectBlocks(i, Arrays.asList(blk),
+          bg.getBlock().getBlockPoolId());
+    }
+    DFSStripedInputStream in =
+        new DFSStripedInputStream(fs.getClient(), filePath.toString(), false,
+            ecPolicy, null);
+    int readSize = BLOCK_GROUP_SIZE;
+    byte[] readBuffer = new byte[readSize];
+    byte[] expected = new byte[readSize];
+
+    /** A variation of {@link DFSTestUtil#fillExpectedBuf} for striped blocks */
+    for (int i = 0; i < NUM_STRIPE_PER_BLOCK; i++) {
+      for (int j = 0; j < DATA_BLK_NUM; j++) {
+        for (int k = 0; k < CELLSIZE; k++) {
+          int posInBlk = i * CELLSIZE + k;
+          int posInFile = i * CELLSIZE * DATA_BLK_NUM + j * CELLSIZE + k;
+          expected[posInFile] = SimulatedFSDataset.simulatedByte(
+              new Block(bg.getBlock().getBlockId() + j), posInBlk);
+        }
+      }
+    }
+
+    ErasureCoderOptions coderOptions = new ErasureCoderOptions(
+        DATA_BLK_NUM, PARITY_BLK_NUM);
+    RawErasureDecoder rawDecoder = CodecUtil.createRawDecoder(conf,
+        ecPolicy.getCodecName(), coderOptions);
+
+    // Update the expected content for decoded data.
+    // It will seem like remoteDNIdx is a failed node.
+    int[] missingBlkIdx = new int[PARITY_BLK_NUM];
+    for (int i = 0; i < missingBlkIdx.length; i++) {
+      if (i == 0) {
+        missingBlkIdx[i] = remoteDNIdx;
+      } else {
+        missingBlkIdx[i] = DATA_BLK_NUM + i;
+      }
+    }
+    for (int i = 0; i < NUM_STRIPE_PER_BLOCK; i++) {
+      byte[][] decodeInputs = new byte[DATA_BLK_NUM + PARITY_BLK_NUM][CELLSIZE];
+      byte[][] decodeOutputs = new byte[missingBlkIdx.length][CELLSIZE];
+      for (int j = 0; j < DATA_BLK_NUM; j++) {
+        int posInBuf = i * CELLSIZE * DATA_BLK_NUM + j * CELLSIZE;
+        if (j != remoteDNIdx) {
+          System.arraycopy(expected, posInBuf, decodeInputs[j], 0, CELLSIZE);
+        }
+      }
+      for (int j = DATA_BLK_NUM; j < DATA_BLK_NUM + PARITY_BLK_NUM; j++) {
+        for (int k = 0; k < CELLSIZE; k++) {
+          int posInBlk = i * CELLSIZE + k;
+          decodeInputs[j][k] = SimulatedFSDataset.simulatedByte(
+              new Block(bg.getBlock().getBlockId() + j), posInBlk);
+        }
+      }
+      for (int m : missingBlkIdx) {
+        decodeInputs[m] = null;
+      }
+      rawDecoder.decode(decodeInputs, missingBlkIdx, decodeOutputs);
+      int posInBuf = i * CELLSIZE * DATA_BLK_NUM + remoteDNIdx * CELLSIZE;
+      System.arraycopy(decodeOutputs[0], 0, expected, posInBuf, CELLSIZE);
+    }
+
+    int delta = 10;
+    int done = 0;
+    // read a small delta, shouldn't trigger decode
+    // |cell_0 |
+    // |10     |
+    done += in.read(0, readBuffer, 0, delta);
+    assertEquals(delta, done);
+    // both head and trail cells are partial
+    // |c_0      |c_1    |c_2 |c_3 |c_4      |c_5         |
+    // |256K - 10|missing|256K|256K|256K - 10|not in range|
+    done += in.read(delta, readBuffer, delta,
+        CELLSIZE * (DATA_BLK_NUM - 1) - 2 * delta);
+    assertEquals(CELLSIZE * (DATA_BLK_NUM - 1) - delta, done);
+    // read the rest
+    done += in.read(done, readBuffer, done, readSize - done);
+    assertEquals(readSize, done);
+    assertArrayEquals(expected, readBuffer);
+  }
+
+}


### PR DESCRIPTION
Added support for the following:

1. Enhanced Namenode to send all the link costs of all DNs hosting blocks in `LocatedStripedBlock` to each DFS client.

2. Protobuf support for encoding & parsing link costs between server and client.

3. Greedy EC chunk selection algorithm to `StripeReader` in `DFSStripedInputStream.java`

4. HDFS options to configure a custom parity computation cost (which is used in the greedy chunk selection algo)

5. HDFS option to disable pipeline sorting. This allows remote DNs to be eligible for hosting data chunks and not just parity chunks.